### PR TITLE
Improve data storage resilience

### DIFF
--- a/src/com/eureka/DataStorageService.java
+++ b/src/com/eureka/DataStorageService.java
@@ -3,33 +3,62 @@ package com.eureka;
 import com.eureka.model.AppState;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 
-import java.io.FileReader;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class DataStorageService {
-    private static final String FILE_PATH = "eureka_data.json";
+    private static final Logger LOGGER = Logger.getLogger(DataStorageService.class.getName());
+    private static final Path FILE_PATH = Paths.get("eureka_data.json");
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
 
     public static void saveData(AppState appState) {
-        try (FileWriter writer = new FileWriter(FILE_PATH)) {
-            gson.toJson(appState, writer);
-            System.out.println("Data saved successfully.");
+        try {
+            ensureParentDirectoryExists();
+            try (Writer writer = Files.newBufferedWriter(FILE_PATH, StandardCharsets.UTF_8)) {
+                gson.toJson(appState, writer);
+                LOGGER.info("Data saved successfully to " + FILE_PATH.toAbsolutePath());
+            }
         } catch (IOException e) {
-            System.err.println("Error saving data to file: " + FILE_PATH);
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "Error saving data to file: " + FILE_PATH.toAbsolutePath(), e);
         }
     }
 
     public static AppState loadData() {
-        try (FileReader reader = new FileReader(FILE_PATH)) {
-            AppState loadedState = gson.fromJson(reader, AppState.class);
-            System.out.println("Data loaded successfully.");
-            return loadedState != null ? loadedState : AppState.createEmptyState();
-        } catch (IOException e) {
-            System.err.println("No existing data file found. Starting with a fresh state.");
+        if (!Files.exists(FILE_PATH)) {
+            LOGGER.info("No existing data file found. Starting with a fresh state.");
             return AppState.createEmptyState();
+        }
+
+        try (Reader reader = Files.newBufferedReader(FILE_PATH, StandardCharsets.UTF_8)) {
+            AppState loadedState = gson.fromJson(reader, AppState.class);
+            if (loadedState == null) {
+                LOGGER.warning("Loaded data was empty or malformed. Starting with a fresh state.");
+                return AppState.createEmptyState();
+            }
+            LOGGER.info("Data loaded successfully from " + FILE_PATH.toAbsolutePath());
+            return loadedState;
+        } catch (JsonParseException e) {
+            LOGGER.log(Level.SEVERE, "Data file is corrupted. Falling back to a fresh state: " + FILE_PATH.toAbsolutePath(), e);
+            return AppState.createEmptyState();
+        } catch (IOException e) {
+            LOGGER.log(Level.SEVERE, "Error loading data from file: " + FILE_PATH.toAbsolutePath(), e);
+            return AppState.createEmptyState();
+        }
+    }
+
+    private static void ensureParentDirectoryExists() throws IOException {
+        Path parent = FILE_PATH.toAbsolutePath().getParent();
+        if (parent != null) {
+            Files.createDirectories(parent);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add logger-based messaging in the data storage service
- switch to NIO APIs for writing and reading JSON data
- harden load/save paths by validating parent directories and handling malformed JSON

## Testing
- javac -cp lib/* -d out $(find src -name '*.java')

------
https://chatgpt.com/codex/tasks/task_e_68dbee25a7cc8322af34099969ef776d